### PR TITLE
Changes required to work on Arduino Leonardo

### DIFF
--- a/src/CmdBuffer.cpp
+++ b/src/CmdBuffer.cpp
@@ -6,7 +6,7 @@
 
 #include "CmdBuffer.hpp"
 
-bool CmdBufferObject::readFromSerial(HardwareSerial *serial, uint32_t timeOut)
+bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
 {
     uint32_t isTimeOut;
     uint32_t startTime;

--- a/src/CmdBuffer.hpp
+++ b/src/CmdBuffer.hpp
@@ -37,7 +37,7 @@ class CmdBufferObject
      * @return              TRUE if data readed until end character or FALSE
      *                      is a timeout receive or buffer is full.
      */
-    bool readFromSerial(HardwareSerial *serial, uint32_t timeOut = 0);
+    bool readFromSerial(Stream *serial, uint32_t timeOut = 0);
 
     /**
      * Set a ASCII character for serial cmd end.

--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -8,7 +8,7 @@
 
 void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
                                           CmdBufferObject *cmdBuffer,
-                                          HardwareSerial * serial)
+                                          Stream * serial)
 {
     do {
         // read data

--- a/src/CmdCallback.hpp
+++ b/src/CmdCallback.hpp
@@ -38,7 +38,7 @@ class CmdCallbackObject
      * @param serial            Arduino serial interface from comming data
      */
     void loopCmdProcessing(CmdParser *cmdParser, CmdBufferObject *cmdBuffer,
-                           HardwareSerial *serial);
+                           Stream *serial);
 
     /**
      * Search command in the buffer and execute the callback function.


### PR DESCRIPTION
Leonardo boards have a very different setup for serial communication, and so use a different class for the `Serial` objects (`Serial_` instead of `HardwareSerial`). Both of these classes inherit from Stream, so rather than delve in to hardware-specific preprocessor work, I've just changed the signature to accept Stream objects.

I've verified the example sketches work with this change on Leonardo and Uno compatible hardware. I'm pretty sure it'll also work with SoftwareSerial, but haven't done more than compile an example sketch.
