### PR TITLE
Fix last parameter count and comparison using flash

### DIFF
--- a/examples/Parser/Parser.ino
+++ b/examples/Parser/Parser.ino
@@ -74,7 +74,7 @@ void loop()
             Serial.println(cmdParser.getParamCount());
 
             const size_t count = cmdParser.getParamCount();
-            for (size_t i = 0; i <= count; i++) {
+            for (size_t i = 0; i < count; i++) {
 
                 Serial.print("Param ");
                 Serial.print(i);

--- a/src/CmdCallback.hpp
+++ b/src/CmdCallback.hpp
@@ -172,12 +172,12 @@ template <size_t STORESIZE>
 class CmdCallback_P : public _CmdCallback<STORESIZE, CmdParserString_P>
 {
     /**
-     * @implement CmdCallbackObject with strcmp_P
+     * @implement CmdCallbackObject with strcasecmp_P
      */
     virtual bool equalStoreCmd(size_t idx, char *cmdStr)
     {
         if (this->checkStorePos(idx) &&
-            strcasecmp_P(this->m_cmdList[idx], cmdStr) == 0) {
+            strcasecmp_P(cmdStr, this->m_cmdList[idx]) == 0) {
             return true;
         }
 
@@ -195,7 +195,7 @@ template <size_t STORESIZE>
 class CmdCallback : public _CmdCallback<STORESIZE, CmdParserString>
 {
     /**
-     * @implement CmdCallbackObject with strcmp_P
+     * @implement CmdCallbackObject with strcasecmp
      */
     virtual bool equalStoreCmd(size_t idx, char *cmdStr)
     {

--- a/src/CmdParser.cpp
+++ b/src/CmdParser.cpp
@@ -38,6 +38,9 @@ uint16_t CmdParser::parseCmd(uint8_t *buffer, size_t bufferSize)
 
         // end
         if (buffer[i] == 0x00 || m_paramCount == 0xFFFE) {
+            if (i > 0 && buffer[i - 1] != 0x00) {
+                m_paramCount++;
+            }
             return m_paramCount;
         }
         // is string "xy zyx" / only the quote option is disabled

--- a/src/CmdParser.cpp
+++ b/src/CmdParser.cpp
@@ -21,7 +21,7 @@ uint16_t CmdParser::parseCmd(uint8_t *buffer, size_t bufferSize)
     bool isString = false;
 
     // init param count
-    m_paramCount ^= m_paramCount;
+    m_paramCount = 0;
 
     // buffer is not okay
     if (buffer == NULL || bufferSize == 0) {


### PR DESCRIPTION
This PR contains 2 major fixes:

While parsing, last parameter was not always count. e.g. with Parser.ino example:
* getParamCount() on "START \"Hallo world\" sensor" should return 3 but was returning 2
* getParamCount() on "START \"Hallo world\" sensor " (note: space at eol) will return 3 as expected
The first commit fixes this behavior and always count the last parameter.

Next, comparison between parsed command and registered one always fails using CmdCallback_P due to strcasecmp_P() usage with reversed ordered arguments.
The last commit fixes arguments order.

The middle commit fixes a useless usage of XOR as (a XOR a) is always equal to 0.