### PR TITLE
Fix buffer fill while receiving command chunks

### DIFF
--- a/src/CmdBuffer.cpp
+++ b/src/CmdBuffer.cpp
@@ -10,22 +10,14 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
 {
     uint32_t isTimeOut;
     uint32_t startTime;
-    size_t   readPtr;
     uint8_t  readChar;
-    uint8_t *buffer   = this->getBuffer();
-    bool     over     = false;
+    uint8_t *buffer = this->getBuffer();
+    bool     over   = false;
 
     // UART initialize?
     if (serial == NULL) {
         return false;
     }
-
-    ////
-    // init buffers
-    this->clear();
-
-    // init Counter
-    readPtr ^= readPtr;
 
     ////
     // Calc Timeout
@@ -49,7 +41,8 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
         while (serial->available()) {
 
             // is buffer full?
-            if (readPtr >= this->getBufferSize()) {
+            if (m_dataOffset >= this->getBufferSize()) {
+                m_dataOffset = 0;
                 return false;
             }
 
@@ -58,12 +51,14 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
 
             // is that the end of command
             if (readChar == m_endChar) {
+                buffer[m_dataOffset] = '\0';
+                m_dataOffset         = 0;
                 return true;
             }
 
             // is a printable character
             if (readChar > CMDBUFFER_CHAR_PRINTABLE) {
-                buffer[readPtr++] = readChar;
+                buffer[m_dataOffset++] = readChar;
             }
         }
 

--- a/src/CmdBuffer.hpp
+++ b/src/CmdBuffer.hpp
@@ -26,7 +26,7 @@ class CmdBufferObject
     /**
      * Clear buffer and set defaults.
      */
-    CmdBufferObject() : m_endChar(CMDBUFFER_CHAR_LF) {}
+    CmdBufferObject() : m_endChar(CMDBUFFER_CHAR_LF), m_dataOffset(0) {}
 
     /**
      * Read data from serial communication to buffer. It read only printable
@@ -67,7 +67,7 @@ class CmdBufferObject
     virtual void clear() = 0;
 
     /**
-     * Return a 0x00 terminatet string
+     * Return a null-terminated ('\0') string
      *
      * @return             String from Buffer
      */
@@ -83,6 +83,7 @@ class CmdBufferObject
   private:
     /** Character for handling the end of serial data communication */
     uint8_t m_endChar;
+    size_t  m_dataOffset;
 };
 
 /**


### PR DESCRIPTION
Due to the nature of serial communication, during reads, sent command can be splitted.
ie. you will not receive whole command in one row.

This commit fixes the way serial byte are stored in buffer: it now fill buffer using an saved offset, reset that offset when m_endChar is reached or buffer overflow.
Please note that when buffer overflow occured, you will loose whole buffer and restart to fill buffer like the behavior before this commit.