### PR TITLE
clear cmdBuffer after each command

### DIFF
--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -20,6 +20,7 @@ void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
                 if (this->processCmd(cmdParser)) {
                     // FIXME: handling cmd not found
                 }
+            	cmdBuffer->clear();
             }
         }
     } while (true);


### PR DESCRIPTION
Scenario, enter following 2 commands:
Command1: "spi init b=1000000 o=MSB m=0 CS=5\r"
Command2: "spi init b=1000000 o=MSB m=0\r"

Issue: For Command2, function getValueFromKey("CS") returns "5" because
it is still in buffer from previous command run.