### PR TITLE
Add optional param to loopCmdProcessing function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,21 @@ myCallbackP.loopCmdProcessing(&myParser, &myBuffer, &Serial);
 // Manual
 myCallbackP.processCmd(cstrCmd);
 ```
+
+### Options
+- optional fourth paramter in loopCmdProcessing to toggle if function returns if no serial characters are to be processed
+```c++
+#include <CmdCallback.hpp>
+
+CmdCallback<5> myCallback; // Object for handling 5 function in SRAM
+CmdBuffer<32> myBuffer;
+CmdParser     myParser;
+
+// add function
+myCallback.addCmd("SET", &myFunctForSet);
+
+// Automatic proccessing
+myCallback.loopCmdProcessing(&myParser, &myBuffer, &Serial, false);
+
+```
+ 

--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -8,8 +8,12 @@
 
 void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
                                           CmdBufferObject *cmdBuffer,
-                                          Stream * serial)
+                                          Stream * serial, 
+                                          bool bLoopAlways=true)
 {
+    if (bLoopAlways == false)
+        if (serial->available() == 0)
+            return;
     do {
         // read data
         if (cmdBuffer->readFromSerial(serial)) {
@@ -20,10 +24,10 @@ void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
                 if (this->processCmd(cmdParser)) {
                     // FIXME: handling cmd not found
                 }
-            	cmdBuffer->clear();
+                if (bLoopAlways) cmdBuffer->clear();
             }
         }
-    } while (true);
+    } while (bLoopAlways);
 }
 
 bool CmdCallbackObject::processCmd(CmdParser *cmdParser)

--- a/src/CmdCallback.hpp
+++ b/src/CmdCallback.hpp
@@ -36,10 +36,11 @@ class CmdCallbackObject
      * @param cmdParser         Parser object with options set
      * @param cmdBuffer         Buffer object for data handling
      * @param serial            Arduino serial interface from comming data
+     * @param bLoopAlways       Loop Always (True) or Loop when data is received and until cmd is processed 
      */
     void loopCmdProcessing(CmdParser *cmdParser, CmdBufferObject *cmdBuffer,
-                           Stream *serial);
-
+                           Stream *serial, bool bLoopAlways);
+                           
     /**
      * Search command in the buffer and execute the callback function.
      *


### PR DESCRIPTION
Allows for the same function to also return processing back to main loop when characters are not present