### PR TITLE
New Buffer and Callback functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .clang_complete
 .gcc-flags.json
 *.gch
+
+# VS Code
+.vscode
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .clang_complete
 .gcc-flags.json
-.gch
+*.gch

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .clang_complete
 .gcc-flags.json
+.gch

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/pvizeli/CmdParser.svg?branch=master)](https://travis-ci.org/pvizeli/CmdParser)
 
 # CmdParser
+
 A simple and most powerfull cmd parser with small memory footprint and realy
 fast algorithm.
 
@@ -34,10 +35,10 @@ myParser.parseCmd(cString); // C string buffer
 ```
 
 ### Options
+
 - ```setOptIgnoreQuote``` (default off) support string with "my value"
 - ```setOptSeperator``` (default ' ') use this character for seperate cmd
 - ```setOptKeyValue``` (default off) Support dynamic key=value feature
-
 
 ## Buffer Object
 
@@ -48,10 +49,16 @@ CmdBuffer<32> myBuffer;
 
 // Reading Data
 myBuffer.readFromSerial(&Serial, numTimeout);
+
+// Read single character
+myBuffer.readSerialChar(&Serial);
 ```
 
 ### Options
+
 - ```setEndChar``` (default '\n') set character for stop reading. Normal is a line end.
+- `setBackChar` (default '\h') set the character for backspace.
+- `setEcho` (default 'false') enable local echo.
 
 ## Callback Object
 
@@ -69,4 +76,12 @@ myCallbackP.loopCmdProcessing(&myParser, &myBuffer, &Serial);
 
 // Manual
 myCallbackP.processCmd(cstrCmd);
+
+// Check for new chars and check if complete command was entered
+// This function is non-blocking to be used in a loop.
+myCallbackP.updateCmdProcessing(&myParser, &myBuffer, &Serial);
+
+// Search command in the buffer, returns true if such command was defined.
+myCallbackP.hasCmd(cstrCmd);
+
 ```

--- a/examples/Callback_non_blocking/Callback_non_blocking.ino
+++ b/examples/Callback_non_blocking/Callback_non_blocking.ino
@@ -1,0 +1,76 @@
+/* Copyright 2016 Pascal Vizeli <pvizeli@syshack.ch>
+ * Copyright 2019 Matthias Homann
+ * BSD License
+ *
+ * https://github.com/pvizeli/CmdParser
+ */
+
+////
+// This example is a demo for non-blocking CmdCallback.
+// It regularly checks for new characters on the serial interface
+// and parses the read string if the 'endchar' (\n) was entered.
+////
+
+#include <CmdBuffer.hpp>
+#include <CmdCallback.hpp>
+#include <CmdParser.hpp>
+
+CmdCallback<3> cmdCallback;
+
+CmdBuffer<32> myBuffer;
+CmdParser     myParser;
+
+char strHallo[] = "HALLO";
+char strQuit[]  = "QUIT";
+char strSet[]   = "SET";
+
+void functHallo(CmdParser *myParser) { Serial.println("Receive Hallo"); }
+
+void functSet(CmdParser *myParser)
+{
+    Serial.println("Receive Set");
+
+    // Alarm
+    if (myParser->equalCmdParam(1, "ALARM")) {
+        Serial.println(myParser->getCmdParam(2));
+    }
+    // Command Unknwon
+    else {
+        Serial.println("Only Alarm is allowed!");
+    }
+}
+
+void functQuit(CmdParser *myParser)
+{
+    Serial.println("Receive Quit");
+}
+
+void setup()
+{
+    Serial.begin(115200);
+
+    cmdCallback.addCmd(strHallo, &functHallo);
+    cmdCallback.addCmd(strQuit, &functQuit);
+    cmdCallback.addCmd(strSet, &functSet);
+
+    // Set parser options:
+    // enable local echo
+    myBuffer.setEcho(true);
+    // ...
+
+    Serial.println("Type you commands. Supported: ");
+    Serial.println("1: hallo");
+    Serial.println("2: set alarm on/off");
+    Serial.println("3: quit");
+
+}
+
+void loop()
+{
+
+    // Check for new char on serial and call function if command was entered
+    cmdCallback.updateCmdProcessing(&myParser, &myBuffer, &Serial);
+
+    // do some other stuff...
+    delay(100);
+}

--- a/examples/Callback_non_blocking/Callback_non_blocking.ino
+++ b/examples/Callback_non_blocking/Callback_non_blocking.ino
@@ -40,10 +40,7 @@ void functSet(CmdParser *myParser)
     }
 }
 
-void functQuit(CmdParser *myParser)
-{
-    Serial.println("Receive Quit");
-}
+void functQuit(CmdParser *myParser) { Serial.println("Receive Quit"); }
 
 void setup()
 {
@@ -62,7 +59,6 @@ void setup()
     Serial.println("1: hallo");
     Serial.println("2: set alarm on/off");
     Serial.println("3: quit");
-
 }
 
 void loop()

--- a/src/CmdBuffer.cpp
+++ b/src/CmdBuffer.cpp
@@ -10,8 +10,6 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
 {
     uint32_t isTimeOut;
     uint32_t startTime;
-    uint8_t  readChar;
-    uint8_t *buffer = this->getBuffer();
     bool     over   = false;
 
     // UART initialize?

--- a/src/CmdBuffer.cpp
+++ b/src/CmdBuffer.cpp
@@ -40,25 +40,8 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
         // if data in serial input buffer
         while (serial->available()) {
 
-            // is buffer full?
-            if (m_dataOffset >= this->getBufferSize()) {
-                m_dataOffset = 0;
-                return false;
-            }
-
-            // read into buffer
-            readChar = serial->read();
-
-            // is that the end of command
-            if (readChar == m_endChar) {
-                buffer[m_dataOffset] = '\0';
-                m_dataOffset         = 0;
-                return true;
-            }
-
-            // is a printable character
-            if (readChar > CMDBUFFER_CHAR_PRINTABLE) {
-                buffer[m_dataOffset++] = readChar;
+            if (this->readSerialChar(serial)) {
+              return true;
             }
         }
 

--- a/src/CmdBuffer.cpp
+++ b/src/CmdBuffer.cpp
@@ -81,3 +81,54 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
 
     return false;
 }
+
+bool CmdBufferObject::readSerialChar(Stream *serial)
+{
+    uint8_t  readChar;
+    uint8_t *buffer = this->getBuffer();
+
+    // UART initialize?
+    if (serial == NULL) {
+        return false;
+    }
+
+    if (serial->available()) {
+        // is buffer full?
+        if (m_dataOffset >= this->getBufferSize()) {
+            m_dataOffset = 0;
+            return false;
+        }
+
+        // read into buffer
+        readChar = serial->read();
+
+        if ( m_echo ) {
+          serial->write(readChar);
+        }
+
+        // is that the end of command
+        if (readChar == m_endChar) {
+            buffer[m_dataOffset] = '\0';
+            m_dataOffset         = 0;
+            return true;
+        }
+
+        // is that a backspace char?
+        if ( (readChar == m_bsChar) && (m_dataOffset >0 ) ) {
+            //buffer[--m_dataOffset] = 0;
+            --m_dataOffset;
+            if ( m_echo ) {
+              serial->write(' ');
+              serial->write(readChar);
+            }
+            return false;
+        }
+
+        // is a printable character
+        if (readChar > CMDBUFFER_CHAR_PRINTABLE) {
+            buffer[m_dataOffset++] = readChar;
+
+        }
+    }
+    return false;
+}

--- a/src/CmdBuffer.cpp
+++ b/src/CmdBuffer.cpp
@@ -10,7 +10,7 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
 {
     uint32_t isTimeOut;
     uint32_t startTime;
-    bool     over   = false;
+    bool     over = false;
 
     // UART initialize?
     if (serial == NULL) {
@@ -39,7 +39,7 @@ bool CmdBufferObject::readFromSerial(Stream *serial, uint32_t timeOut)
         while (serial->available()) {
 
             if (this->readSerialChar(serial)) {
-              return true;
+                return true;
             }
         }
 
@@ -83,8 +83,8 @@ bool CmdBufferObject::readSerialChar(Stream *serial)
         // read into buffer
         readChar = serial->read();
 
-        if ( m_echo ) {
-          serial->write(readChar);
+        if (m_echo) {
+            serial->write(readChar);
         }
 
         // is that the end of command
@@ -95,12 +95,12 @@ bool CmdBufferObject::readSerialChar(Stream *serial)
         }
 
         // is that a backspace char?
-        if ( (readChar == m_bsChar) && (m_dataOffset >0 ) ) {
-            //buffer[--m_dataOffset] = 0;
+        if ((readChar == m_bsChar) && (m_dataOffset > 0)) {
+            // buffer[--m_dataOffset] = 0;
             --m_dataOffset;
-            if ( m_echo ) {
-              serial->write(' ');
-              serial->write(readChar);
+            if (m_echo) {
+                serial->write(' ');
+                serial->write(readChar);
             }
             return false;
         }
@@ -108,7 +108,6 @@ bool CmdBufferObject::readSerialChar(Stream *serial)
         // is a printable character
         if (readChar > CMDBUFFER_CHAR_PRINTABLE) {
             buffer[m_dataOffset++] = readChar;
-
         }
     }
     return false;

--- a/src/CmdBuffer.hpp
+++ b/src/CmdBuffer.hpp
@@ -28,10 +28,13 @@ class CmdBufferObject
     /**
      * Clear buffer and set defaults.
      */
-    CmdBufferObject() : m_endChar(CMDBUFFER_CHAR_LF),
-                        m_bsChar(CMDBUFFER_CHAR_BS),
-                        m_dataOffset(0),
-                        m_echo(false) {}
+    CmdBufferObject()
+        : m_endChar(CMDBUFFER_CHAR_LF),
+          m_bsChar(CMDBUFFER_CHAR_BS),
+          m_dataOffset(0),
+          m_echo(false)
+    {
+    }
 
     /**
      * Read data from serial communication to buffer. It read only printable
@@ -121,7 +124,7 @@ class CmdBufferObject
     uint8_t m_endChar;
     uint8_t m_bsChar;
     size_t  m_dataOffset;
-    bool m_echo;
+    bool    m_echo;
 };
 
 /**

--- a/src/CmdBuffer.hpp
+++ b/src/CmdBuffer.hpp
@@ -15,6 +15,8 @@
 const uint8_t CMDBUFFER_CHAR_PRINTABLE = 0x1F;
 const uint8_t CMDBUFFER_CHAR_LF        = 0x0A;
 const uint8_t CMDBUFFER_CHAR_CR        = 0x0D;
+const uint8_t CMDBUFFER_CHAR_BS        = 0x08;
+const uint8_t CMDBUFFER_CHAR_DEL       = 0x7F;
 
 /**
  *
@@ -26,7 +28,10 @@ class CmdBufferObject
     /**
      * Clear buffer and set defaults.
      */
-    CmdBufferObject() : m_endChar(CMDBUFFER_CHAR_LF), m_dataOffset(0) {}
+    CmdBufferObject() : m_endChar(CMDBUFFER_CHAR_LF),
+                        m_bsChar(CMDBUFFER_CHAR_BS),
+                        m_dataOffset(0),
+                        m_echo(false) {}
 
     /**
      * Read data from serial communication to buffer. It read only printable
@@ -40,8 +45,20 @@ class CmdBufferObject
     bool readFromSerial(Stream *serial, uint32_t timeOut = 0);
 
     /**
+     * Read one char from serial communication to buffer if available.
+     * It read only printable ASCII character from serial.
+     * All other will ignore for buffer. This function only ready currently
+     * available data and doesn't wait for a full command (= end character)
+     *
+     * @param serial        Arduino Serial object from read commands
+     * @return              TRUE if data readed until end character or
+     *                      FALSE if not.
+     */
+    bool readSerialChar(Stream *serial);
+
+    /**
      * Set a ASCII character for serial cmd end.
-     " Default value is LF.
+     * Default value is LF.
      *
      * Macros for helping are:
      * - CMDBUFFER_CHAR_LF
@@ -50,6 +67,25 @@ class CmdBufferObject
      * @param end       ASCII character
      */
     void setEndChar(uint8_t end) { m_endChar = end; }
+
+    /**
+     * Set a ASCII character for serial cmd backspace.
+     * Default value is BS.
+     *
+     * Macros for helping are:
+     * - CMDBUFFER_CHAR_BS
+     * - CMDBUFFER_CHAR_DEL
+     *
+     * @param backspace       ASCII character
+     */
+    void setBackChar(uint8_t backspace) { m_bsChar = backspace; }
+
+    /**
+     * Set echo serial on (true) or off (false)
+     *
+     * @param echo      bool
+     */
+    void setEcho(bool echo) { m_echo = echo; }
 
     /**
      * Cast Buffer to c string.
@@ -83,6 +119,8 @@ class CmdBufferObject
   private:
     /** Character for handling the end of serial data communication */
     uint8_t m_endChar;
+    uint8_t m_bsChar;
+    bool m_echo;
     size_t  m_dataOffset;
 };
 

--- a/src/CmdBuffer.hpp
+++ b/src/CmdBuffer.hpp
@@ -120,8 +120,8 @@ class CmdBufferObject
     /** Character for handling the end of serial data communication */
     uint8_t m_endChar;
     uint8_t m_bsChar;
-    bool m_echo;
     size_t  m_dataOffset;
+    bool m_echo;
 };
 
 /**

--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -17,8 +17,8 @@ void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
             // parse command line
             if (cmdParser->parseCmd(cmdBuffer) != CMDPARSER_ERROR) {
                 // search command in store and call function
-                // ignore return value "false" if ommand was not found
-                this->processCmd(cmdParser));
+                // ignore return value "false" if command was not found
+                this->processCmd(cmdParser);
                 cmdBuffer->clear();
             }
         }
@@ -56,8 +56,8 @@ void CmdCallbackObject::updateCmdProcessing(CmdParser *      cmdParser,
         // parse command line
         if (cmdParser->parseCmd(cmdBuffer) != CMDPARSER_ERROR) {
             // search command in store and call function
-            // ignore return value "false" if ommand was not found
-            this->processCmd(cmdParser));
+            // ignore return value "false" if command was not found
+            this->processCmd(cmdParser);
             cmdBuffer->clear();
         }
     }

--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -20,7 +20,7 @@ void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
                 if (this->processCmd(cmdParser)) {
                     // FIXME: handling cmd not found
                 }
-            	cmdBuffer->clear();
+                cmdBuffer->clear();
             }
         }
     } while (true);
@@ -42,6 +42,37 @@ bool CmdCallbackObject::processCmd(CmdParser *cmdParser)
         if (this->equalStoreCmd(i, cmdStr)) {
             // call function
             return this->callStoreFunct(i, cmdParser);
+        }
+    }
+
+    return false;
+}
+
+void CmdCallbackObject::updateCmdProcessing(CmdParser *      cmdParser,
+                                            CmdBufferObject *cmdBuffer,
+                                            Stream * serial)
+{
+    // read data and check if command was entered
+    if (cmdBuffer->readSerialChar(serial)) {
+        // parse command line
+        if (cmdParser->parseCmd(cmdBuffer) != CMDPARSER_ERROR) {
+            // search command in store and call function
+            if (this->processCmd(cmdParser)) {
+                // FIXME: handling cmd not found
+            }
+            cmdBuffer->clear();
+        }
+    }
+}
+
+bool CmdCallbackObject::hasCmd(char *cmdStr)
+{
+    // search cmd in store
+    for (size_t i = 0; this->checkStorePos(i); i++) {
+
+        // compare command with string
+        if (this->equalStoreCmd(i, cmdStr)) {
+            return true;
         }
     }
 

--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -8,7 +8,7 @@
 
 void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
                                           CmdBufferObject *cmdBuffer,
-                                          Stream * serial)
+                                          Stream *         serial)
 {
     do {
         // read data
@@ -50,7 +50,7 @@ bool CmdCallbackObject::processCmd(CmdParser *cmdParser)
 
 void CmdCallbackObject::updateCmdProcessing(CmdParser *      cmdParser,
                                             CmdBufferObject *cmdBuffer,
-                                            Stream * serial)
+                                            Stream *         serial)
 {
     // read data and check if command was entered
     if (cmdBuffer->readSerialChar(serial)) {

--- a/src/CmdCallback.cpp
+++ b/src/CmdCallback.cpp
@@ -17,9 +17,8 @@ void CmdCallbackObject::loopCmdProcessing(CmdParser *      cmdParser,
             // parse command line
             if (cmdParser->parseCmd(cmdBuffer) != CMDPARSER_ERROR) {
                 // search command in store and call function
-                if (this->processCmd(cmdParser)) {
-                    // FIXME: handling cmd not found
-                }
+                // ignore return value "false" if ommand was not found
+                this->processCmd(cmdParser));
                 cmdBuffer->clear();
             }
         }
@@ -57,9 +56,8 @@ void CmdCallbackObject::updateCmdProcessing(CmdParser *      cmdParser,
         // parse command line
         if (cmdParser->parseCmd(cmdBuffer) != CMDPARSER_ERROR) {
             // search command in store and call function
-            if (this->processCmd(cmdParser)) {
-                // FIXME: handling cmd not found
-            }
+            // ignore return value "false" if ommand was not found
+            this->processCmd(cmdParser));
             cmdBuffer->clear();
         }
     }

--- a/src/CmdCallback.hpp
+++ b/src/CmdCallback.hpp
@@ -56,7 +56,7 @@ class CmdCallbackObject
      * @param serial            Arduino serial interface from comming data
      */
     void updateCmdProcessing(CmdParser *cmdParser, CmdBufferObject *cmdBuffer,
-                           Stream *serial);
+                             Stream *serial);
 
     /**
      * Search command in the buffer.

--- a/src/CmdCallback.hpp
+++ b/src/CmdCallback.hpp
@@ -49,6 +49,24 @@ class CmdCallbackObject
     virtual bool processCmd(CmdParser *cmdParser);
 
     /**
+     * Check for single new char on serial and if it was the endChar
+     *
+     * @param cmdParser         Parser object with options set
+     * @param cmdBuffer         Buffer object for data handling
+     * @param serial            Arduino serial interface from comming data
+     */
+    void updateCmdProcessing(CmdParser *cmdParser, CmdBufferObject *cmdBuffer,
+                           Stream *serial);
+
+    /**
+     * Search command in the buffer.
+     *
+     * @param cmdStr            Cmd string to search
+     * @return                  TRUE if found the command in the buffer
+     */
+    virtual bool hasCmd(char *cmdStr);
+
+    /**
      * Give the size of callback store.
      *
      * @return                  Size of callback Store


### PR DESCRIPTION
I added some new functions to the Buffer and Callback objects.

In the CmdBuffer object I added a non-blocking function 'readSerialChar' for reading a single char from the input stream. This function also supports a backspace char so that typos can be corrected. If required, a local echo can be enabled so that the typed command is visible on the serial terminal.
The backspace character can be defined by the option 'BackChar' and the local echo can be enabled by the option 'setEcho'.
The 'readFromSerial' function was modified to use the 'readSerialChar' function.

The CmdCallback object was enhanced with a non-blocking function 'updateCmdProcessing' which reads a single char (with above readSerialChar)if available and processes the command if the EndChar was found. It is intended to be used in a loop so that other code can still be executed while a new command is entered. This provides the feature requested in issue #2

Another small function added to the CmdCallback object is the function 'hasCmd' to check for defined commands.

For the non-blocking command callback I added an example 'Callback_non_blocking'.

