### PR TITLE
Add new method to look for a flag in all parameters

### DIFF
--- a/src/CmdParser.hpp
+++ b/src/CmdParser.hpp
@@ -143,7 +143,7 @@ class CmdParser
     }
 
     /**
-     * Check if a parameter/flag exists among all
+     * Checks if a parameter/flag exists among all
      * other passed command parameters.
      *
      * @param value             String to look for among the parameters

--- a/src/CmdParser.hpp
+++ b/src/CmdParser.hpp
@@ -105,7 +105,10 @@ class CmdParser
      */
     bool equalCmdParam(uint16_t idx, CmdParserString value)
     {
-        if (strcasecmp(this->getCmdParam(idx), value) == 0) {
+        const char *param_actual_value = this->getCmdParam(idx);
+
+        if (param_actual_value != NULL &&
+            strcasecmp(param_actual_value, value) == 0) {
             return true;
         }
 
@@ -134,6 +137,24 @@ class CmdParser
     {
         if (strcasecmp(this->getValueFromKey(key, false), value) == 0) {
             return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if value a parameter (or a flag) exists between all parameters or
+     * flags.
+     *
+     * @param value             String to look for in parameters
+     * @return                  TRUE is exists
+     */
+    bool equalCmdParamFromAll(CmdParserString value)
+    {
+        for (uint16_t i = 1; i < m_paramCount; i++) {
+            if (equalCmdParam(i, value)) {
+                return true;
+            }
         }
 
         return false;

--- a/src/CmdParser.hpp
+++ b/src/CmdParser.hpp
@@ -143,13 +143,13 @@ class CmdParser
     }
 
     /**
-     * Check if value a parameter (or a flag) exists between all parameters or
-     * flags.
+     * Check if a parameter/flag exists among all
+     * other passed command parameters.
      *
-     * @param value             String to look for in parameters
-     * @return                  TRUE is exists
+     * @param value             String to look for among the parameters
+     * @return                  TRUE if found
      */
-    bool equalCmdParamFromAll(CmdParserString value)
+    bool cmdParamExists(CmdParserString value)
     {
         for (uint16_t i = 1; i < m_paramCount; i++) {
             if (equalCmdParam(i, value)) {


### PR DESCRIPTION
This saves from creating a new function that iterates through all flags (params).

Also, a NULL check is added to avoid crash if parameter is out of range.